### PR TITLE
Refactor dropdown menus to use CommonDropdownMenuItem

### DIFF
--- a/app/src/main/java/com/d4rk/cartcalculator/app/cart/list/ui/components/CartDropdownMenu.kt
+++ b/app/src/main/java/com/d4rk/cartcalculator/app/cart/list/ui/components/CartDropdownMenu.kt
@@ -9,10 +9,10 @@ import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material.icons.outlined.MoreVert
 import androidx.compose.material.icons.outlined.Share
 import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
+import com.d4rk.android.libs.apptoolkit.core.ui.components.dropdown.CommonDropdownMenuItem
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalView
@@ -34,18 +34,21 @@ fun CartDropdownMenu(
             Icon(imageVector = Icons.Outlined.MoreVert , contentDescription = stringResource(id = R.string.more_options))
         }
         DropdownMenu(expanded = expanded , onDismissRequest = { onDismissRequest() }) {
-            DropdownMenuItem(modifier = Modifier.bounceClick() , text = { Text(text = stringResource(id = R.string.rename_cart)) } , onClick = {
-                view.playSoundEffect(SoundEffectConstants.CLICK)
-                onRename()
-            } , leadingIcon = { Icon(Icons.Outlined.Edit , contentDescription = stringResource(id = R.string.rename_cart)) })
-            DropdownMenuItem(modifier = Modifier.bounceClick() , text = { Text(text = stringResource(id = com.d4rk.android.libs.apptoolkit.R.string.share)) } , onClick = {
-                view.playSoundEffect(SoundEffectConstants.CLICK)
-                onShare()
-            } , leadingIcon = { Icon(Icons.Outlined.Share , contentDescription = stringResource(id = R.string.share_cart)) })
-            DropdownMenuItem(modifier = Modifier.bounceClick() , text = { Text(text = stringResource(id = R.string.delete_cart)) } , onClick = {
-                view.playSoundEffect(SoundEffectConstants.CLICK)
-                onDelete()
-            } , leadingIcon = { Icon(Icons.Outlined.Delete , contentDescription = stringResource(id = R.string.delete_cart)) })
+            CommonDropdownMenuItem(
+                textResId = R.string.rename_cart,
+                icon = Icons.Outlined.Edit,
+                onClick = onRename
+            )
+            CommonDropdownMenuItem(
+                textResId = com.d4rk.android.libs.apptoolkit.R.string.share,
+                icon = Icons.Outlined.Share,
+                onClick = onShare
+            )
+            CommonDropdownMenuItem(
+                textResId = R.string.delete_cart,
+                icon = Icons.Outlined.Delete,
+                onClick = onDelete
+            )
         }
     }
 }

--- a/app/src/main/java/com/d4rk/cartcalculator/app/main/ui/components/navigation/MainTopAppBar.kt
+++ b/app/src/main/java/com/d4rk/cartcalculator/app/main/ui/components/navigation/MainTopAppBar.kt
@@ -19,7 +19,6 @@ import androidx.compose.material.icons.outlined.MicNone
 import androidx.compose.material.icons.outlined.MoreVert
 import androidx.compose.material.icons.outlined.VolunteerActivism
 import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -46,6 +45,7 @@ import androidx.navigation.NavHostController
 import com.d4rk.android.libs.apptoolkit.app.support.ui.SupportActivity
 import com.d4rk.android.libs.apptoolkit.core.ui.components.buttons.AnimatedIconButtonDirection
 import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.bounceClick
+import com.d4rk.android.libs.apptoolkit.core.ui.components.dropdown.CommonDropdownMenuItem
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.IntentsHelper
 import com.d4rk.cartcalculator.R
@@ -198,20 +198,14 @@ fun MainTopAppBar(
                 onClick = { expandedMenu = true },
             )
             DropdownMenu(expanded = expandedMenu, onDismissRequest = { expandedMenu = false }) {
-                DropdownMenuItem(
-                    modifier = Modifier.bounceClick(),
-
-                    text = { Text(stringResource(id = com.d4rk.android.libs.apptoolkit.R.string.support_us)) },
+                CommonDropdownMenuItem(
+                    textResId = com.d4rk.android.libs.apptoolkit.R.string.support_us,
+                    icon = Icons.Outlined.VolunteerActivism,
                     onClick = {
                         expandedMenu = false
                         IntentsHelper.openActivity(context , SupportActivity::class.java)
-                    },
-                    leadingIcon = {
-                        Icon(
-                            Icons.Outlined.VolunteerActivism,
-                            contentDescription = stringResource(id = com.d4rk.android.libs.apptoolkit.R.string.support_us)
-                        )
-                    })
+                    }
+                )
             }
         }
     }, scrollBehavior = scrollBehavior, windowInsets = TopAppBarDefaults.windowInsets)


### PR DESCRIPTION
## Summary
- use the CommonDropdownMenuItem from App Toolkit
- simplify CartDropdownMenu and MainTopAppBar

## Testing
- `./gradlew test -q` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884f2707d34832dae252d506bd72b03