### PR TITLE
Fix price rounding to retain two decimals in cart

### DIFF
--- a/app/src/main/java/com/d4rk/cartcalculator/app/cart/details/ui/components/CartItem.kt
+++ b/app/src/main/java/com/d4rk/cartcalculator/app/cart/details/ui/components/CartItem.kt
@@ -108,7 +108,12 @@ fun CartItem(viewModel : CartViewModel , cartItem : ShoppingCartItemsTable , onM
                     Column(modifier = Modifier.weight(weight = 1f)) {
                         Text(text = cartItem.name , style = MaterialTheme.typography.bodyLarge , modifier = Modifier.basicMarquee())
                         Row {
-                            Text(text = String.format(Locale.getDefault() , "%.1f" , cartItem.price.toFloat()).removeSuffix(suffix = ".0"))
+                            Text(
+                                text = String
+                                        .format(Locale.getDefault() , "%.2f" , cartItem.price.toFloat())
+                                        .trimEnd('0')
+                                        .trimEnd('.')
+                            )
                             ExtraSmallHorizontalSpacer()
                             uiState.data?.selectedCurrency?.let { Text(text = it , style = MaterialTheme.typography.bodyLarge) }
                         }

--- a/app/src/main/java/com/d4rk/cartcalculator/app/cart/details/ui/components/PriceText.kt
+++ b/app/src/main/java/com/d4rk/cartcalculator/app/cart/details/ui/components/PriceText.kt
@@ -10,7 +10,10 @@ import java.util.Locale
 
 @Composable
 fun PriceText(price : Float , currency : String , modifier : Modifier = Modifier) {
-    val formattedPrice : String = String.format(Locale.getDefault() , "%.1f" , price).removeSuffix(suffix = ".0") + " $currency"
+    val formattedPrice : String = String
+            .format(Locale.getDefault() , "%.2f" , price)
+            .trimEnd('0')
+            .trimEnd('.') + " $currency"
 
     Row(modifier = modifier) {
         formattedPrice.forEach { char : Char ->


### PR DESCRIPTION
## Summary
- Display prices with up to two decimal places
- Trim trailing zeros from formatted currency values

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892526bc094832dac3ae9232fead7aa